### PR TITLE
Add command-line arguments to server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ After starting the application, you can send POST requests to `http://localhost:
 
 Detailed API documentation and example requests will be provided in a separate document.
 
+## Command-line Arguments
+
+```txt
+usage: flocap.py [-h] [--port PORT] [--listen] [--debug]
+
+Florence-2 Captioning API
+
+options:
+  -h, --help   show this help message and exit
+  --port PORT  Specify the port on which the application is hosted
+  --listen     Host the app on the local network
+  --debug      Enable debug mode for the Flask app
+```
+
 ## Contributing
 
 Contributions to the Florence 2 API App are welcome. Please feel free to submit pull requests or create issues for bugs and feature requests.

--- a/flocap.py
+++ b/flocap.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import time
+import argparse
 import torch
 from flask import Flask, request, jsonify
 from flask_cors import CORS
@@ -40,6 +41,25 @@ def fixed_get_imports(filename: str | os.PathLike) -> list[str]:
 
 app = Flask(__name__)
 CORS(app)
+
+parser = argparse.ArgumentParser(
+    prog="flocap.py", description="Florence-2 Captioning API"
+)
+parser.add_argument(
+    "--port", type=int, help="Specify the port on which the application is hosted"
+)
+parser.add_argument(
+    "--listen", action="store_true", help="Host the app on the local network"
+)
+parser.add_argument(
+    "--debug", action="store_true", help="Enable debug mode for the Flask app"
+)
+
+args = parser.parse_args()
+host = "0.0.0.0" if args.listen else "127.0.0.1"
+port = int(args.port) if args.port else 5000
+debug = bool(args.debug) if args.debug else False
+
 # logging.basicConfig(level=logging.DEBUG)
 
 # Enhanced GPU detection and information
@@ -213,4 +233,4 @@ def chat_completions():
     return jsonify(response)
 
 if __name__ == '__main__':
-    app.run(debug=True,host="0.0.0.0")
+    app.run(debug=debug, host=host, port=port)


### PR DESCRIPTION
Adds several command-line flags for easier server startup customization using a standard Python argparse library.

* `--port` = sets a hosting port for the server. Default: 5000
* `--listen` = sets a "listen mode" for the server (host on 0.0.0.0). Default: false (host on 127.0.0.1).
* `--debug` = sets a debug mode for Flask app. Default: false.